### PR TITLE
Clarify Nightly package section

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ mamba activate $PWD/condaenv
 
 ### Build
 
-Clone this www repository. Then, in the root directory of this repository, 
+Clone this www repository. Then, in the root directory of this repository,
 install the dependencies:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ mamba activate $PWD/condaenv
 
 ### Build
 
-In the root directory of the project install the dependencies:
+Clone this www repository. Then, in the root directory of this repository, 
+install the dependencies:
 
 ```sh
 pip install -r requirements.txt

--- a/source/installation/index.rst
+++ b/source/installation/index.rst
@@ -36,11 +36,12 @@ Instructions:
 Nightly Build
 #############
 
+Go to our `releases page on Github <https://github.com/mantidproject/mantid/releases>`__,
+find the latest nightly and download the relevant package.
+
 .. include:: ./nightly_build_warning.txt
 
-Our nightly builds are hosted on GitHub.
-Please visit our `releases <https://github.com/mantidproject/mantid/releases>`__
-page, find the latest nightly and download the relevant package.
+----
 
 .. _installation_conda:
 

--- a/source/installation/index.rst
+++ b/source/installation/index.rst
@@ -81,6 +81,8 @@ to the channel:
 
    conda install -c mantid/label/nightly mantid
 
+----
+
 Sample Data
 -----------
 

--- a/source/installation/nightly_build_warning.txt
+++ b/source/installation/nightly_build_warning.txt
@@ -1,5 +1,5 @@
 .. warning::
 
-   Not recommended for production use.
+   Nightly version NOT recommended for production use.
    These packages have passed all automated checks but have only had minimal
    manual testing. Use with caution.


### PR DESCRIPTION
Draw the eye more towards the nightly package link by putting more words in the link, moving the warning below the text and adding a transition marker (horizontal line to separate it from the Conda section)

Fixes #18