### PR TITLE
Show 2 levels in table of contents sidebar

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -42,6 +42,7 @@ html_context = {
 
 # Next/previous don't really appy here
 html_theme_options = {
+    "show_toc_level": 2,
     "show_prev_next": False,
 }
 


### PR DESCRIPTION
Further to clarification in #19 around the nightly build. Show 2 levels of table of contents by default so links to the nightly section of visible at the top of the page.