### PR TITLE
trigger deploy workflow after updating latest release links

### DIFF
--- a/.github/workflows/deploy-ghpages.yml
+++ b/.github/workflows/deploy-ghpages.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+  workflow_run:
+    workflows: [Update latest release links]
+    types:
+      - completed
 
 permissions:
   contents: write


### PR DESCRIPTION
Although the action to `Deploy to GitHub Pages` is triggered by a push to main, it is not triggered when main is pushed to by another action. Here we add a trigger to make sure the action is run after the `Update latest release links` action has run.