### PR TITLE
Added instructions for M1 and M2 osx devices

### DIFF
--- a/source/installation/index.rst
+++ b/source/installation/index.rst
@@ -89,7 +89,7 @@ or the ``mantidworkbench`` package containing the graphical-user-interface
 
    mamba create -n mantid_env -c mantid mantidworkbench
 
-At present we only provide x86 release for OSX. This can still be used by those with Apple Silicon devices (M1, M2). You will need to have Rosetta installed and preceed the setup commands with 'CONDA_SUBDIR=osx-64'.
+For macOS we currently only provide x86 packages. These can still be used by those with Apple silicon devices (M1, M2). You will need to have Rosetta installed and precede the setup commands with 'CONDA_SUBDIR=osx-64'.
 For example if you want to install mantidworkbench use the following command:
 
 .. code-block:: sh

--- a/source/installation/index.rst
+++ b/source/installation/index.rst
@@ -88,7 +88,7 @@ or the ``mantidworkbench`` package containing the graphical-user-interface
 .. code-block:: sh
 
    mamba create -n mantid_env -c mantid mantidworkbench
-   
+
 At present we only provide x86 release for OSX. This can still be used by those with Apple Silicon devices (M1, M2). You will need to have Rosetta installed and preceed the setup commands with 'CONDA_SUBDIR=osx-64'.
 For example if you want to install mantidworkbench use the following command:
 

--- a/source/installation/index.rst
+++ b/source/installation/index.rst
@@ -88,6 +88,13 @@ or the ``mantidworkbench`` package containing the graphical-user-interface
 .. code-block:: sh
 
    mamba create -n mantid_env -c mantid mantidworkbench
+   
+At present we only provide x86 release for OSX. This can still be used by those with Apple Silicon devices (M1, M2). You will need to have Rosetta installed and preceed the setup commands with 'CONDA_SUBDIR=osx-64'.
+For example if you want to install mantidworkbench use the following command:
+
+.. code-block:: sh
+
+	CONDA_SUBDIR=osx-64 mamba create -n mantid_env -c mantid mantidworkbench
 
 Nightly Build
 #############


### PR DESCRIPTION
Currently we only provide an x86 package. This will work with M1 and M2 machines but an extra command is required to install it. This PR update the installation documentation page to provide details of how to do this.