### PR TITLE
Update linux standalone install instructions

### DIFF
--- a/source/installation/index.rst
+++ b/source/installation/index.rst
@@ -6,42 +6,12 @@ Installation
 Here you can find instructions on how to install Mantid on various platforms.
 We currently offer:
 
-- :ref:`full installers <installation_full>` bundling
-  all components (64-bit, Intel)
 - :ref:`Conda packages <installation_conda>` for use with the
   `conda package manager <https://docs.conda.io/en/latest/>`__ (64-bit, Intel)
+- :ref:`full installers <installation_full>` bundling
+  all components (64-bit, Intel)
 
 Please see the relevant sections for installation instructions.
-
-.. _installation_full:
-
-Full Installers
----------------
-
-Latest Release
-##############
-
-.. raw:: html
-   :file: latest.html
-
-Instructions:
-
-- :doc:`Windows <windows>`
-- :doc:`macOS <macos>`
-- :doc:`Linux <linux>`: Starting with version ``6.4`` the above `.tar.xz` file for Linux can
-  simply be extracted and run on any modern Linux (>2010) system.
-  Prior and up to versions ``6.4``, ``rpm`` and ``deb`` versions are available for
-  Red Hat/CentOS 7 and various versions of Ubuntu: 18.04, 16.04, 14.04.
-
-Nightly Build
-#############
-
-Go to our `releases page on Github <https://github.com/mantidproject/mantid/releases>`__,
-find the latest nightly and download the relevant package.
-
-.. include:: ./nightly_build_warning.txt
-
-----
 
 .. _installation_conda:
 
@@ -112,6 +82,38 @@ Then you can open Mantid with the following command:
 .. code-block:: sh
 
    workbench
+
+----
+
+.. _installation_full:
+
+Full Installers
+---------------
+
+Latest Release
+##############
+
+.. raw:: html
+   :file: latest.html
+
+Instructions:
+
+- :doc:`Windows <windows>`
+- :doc:`macOS <macos>`
+- :doc:`Linux <linux>`: Starting with version ``6.4`` the above `.tar.xz` file for Linux can
+  simply be extracted and run on any modern Linux (>2010) system.
+  Prior and up to versions ``6.4``, ``rpm`` and ``deb`` versions are available for
+  Red Hat/CentOS 7 and various versions of Ubuntu: 18.04, 16.04, 14.04.
+
+Nightly Build
+#############
+
+Go to our `releases page on Github <https://github.com/mantidproject/mantid/releases>`__,
+find the latest nightly and download the relevant package.
+
+.. include:: ./nightly_build_warning.txt
+
+----
 
 Sample Data
 -----------

--- a/source/installation/linux.rst
+++ b/source/installation/linux.rst
@@ -5,6 +5,6 @@ Linux Packages
 
 The steps below will guide you through installation of MantidWorkbench on Linux:
 
-1. Unpack the ``tar.xz`` file using ``tar -xf`` (e.g ``tar -xf mantidworkbench-6.11.tar.xz``).
+1. Unpack the ``tar.xz`` file using ``tar -xJf`` (e.g ``tar -xJf mantidworkbench-6.11.tar.xz``).
 2. This will create a directory with the package name (e.g ``/mantidworkbench-6.11``).
-3. Enter this directory and run ``./bin/mantidworkbench`` to launch.
+3. ``cd`` into this directory and run ``./bin/mantidworkbench`` to launch.

--- a/source/installation/linux.rst
+++ b/source/installation/linux.rst
@@ -3,78 +3,8 @@
 Linux Packages
 ==============
 
-Red Hat/CentOS 7
-----------------
+The steps below will guide you through installation of MantidWorkbench on Linux:
 
-Setup
-#####
-
-Enable the `Extra Packages for Enterprise Linux (EPEL) <https://docs.fedoraproject.org/en-US/epel/#_el7>`_
-repositories.
-
-Activate the yum repository for the version of Mantid you require by
-downloading the appropriate repository configuration file and saving it to ``/etc/yum.repos.d``:
-
-- `stable release <_static/isis-rhel.repo>`__
-- `nightly build <_static/isis-rhel-testing.repo>`__
-
-Installation
-############
-
-Install the version of Mantid you require with:
-
-- stable release: ``yum install mantid``. Installs to ``/opt/Mantid``
-- nightly build: ``yum install mantidnightly``. Installs to ``/opt/mantidnightly``
-
-Run
-###
-
-To run MantidWorkbench:
-
-- stable release: ``/opt/Mantid/bin/mantidworkbench``
-- nightly build: ``/opt/mantidnightly/bin/mantidworkbench``
-
-Ubuntu
-------
-
-Setup
-#####
-
-Enable the ``mantid`` prerequisites PPA:
-
-.. code-block:: sh
-
-   sudo apt-add-repository ppa:mantid/mantid
-
-Add the ``mantid`` signing key to your key chain:
-
-.. code-block:: sh
-
-   wget -O - http://apt.isis.rl.ac.uk/2E10C193726B7213.asc | sudo apt-key add -
-
-Activate the apt repository for the version of Mantid you require by running:
-
-- stable release: ``sudo apt-add-repository "deb [arch=amd64] http://apt.isis.rl.ac.uk $(lsb_release -c | cut -f 2) main"``
-- nightly build: ``sudo apt-add-repository "deb [arch=amd64] http://apt.isis.rl.ac.uk $(lsb_release -c | cut -f 2)-testing main"``
-
-and force an apt update:
-
-.. code-block:: sh
-
-   sudo apt-get update
-
-Installation
-############
-
-Install the version of Mantid you require with:
-
-- stable release: ``apt install mantid``. Installs to ``/opt/Mantid``
-- nightly build: ``apt install mantidnightly``. Installs to ``/opt/mantidnightly``
-
-Run
-###
-
-To run MantidWorkbench:
-
-- stable release: ``/opt/Mantid/bin/mantidworkbench``
-- nightly build: ``/opt/mantidnightly/bin/mantidworkbench``
+1. Unpack the ``tar.xz`` file using ``tar -xf`` (e.g ``tar -xf mantidworkbench-6.11.tar.xz``).
+2. This will create a directory with the package name (e.g ``/mantidworkbench-6.11``).
+3. Enter this directory and run ``./bin/mantidworkbench`` to launch.


### PR DESCRIPTION
Linux package instructions were out of date, caused some confusion for a user, so I've updated them.

I also moved the conda install instructions to the top of the index page, since that's what we recommend.

Fixes https://github.com/mantidproject/mantid/issues/38695