### PR TITLE
Add Native macOS ARM Instructions to Conda Install Docs

### DIFF
--- a/source/installation/condafaq.rst
+++ b/source/installation/condafaq.rst
@@ -38,22 +38,22 @@ You may also encounter this error when trying to install on Apple silicon device
 Installing on Apple silicon devices
 ###################################
 
-On macOS we provide both an Intel (x86) and Apple Silicon (ARM) package from 
+On macOS we provide both an Intel (x86) and Apple Silicon (ARM) package from
 v6.13 onwards. Mamba will automatically determine  which package to install
 based on your device.
 
-The processor in your machine can be found by navigating to the ``Apple logo`` 
--> ``About This Mac``. On an Apple Silicon device, the ``Chip`` 
+The processor in your machine can be found by navigating to the ``Apple logo``
+-> ``About This Mac``. On an Apple Silicon device, the ``Chip``
 line will say ``Apple M`` then a number indicating the version of the chip on
 the device. An Intel device will have a ``Processor`` line, followed by some
 details of the specific CPU used in the device.
 
-For versions of mantid prior to v6.13, only x86 packages are available. These 
-can still be used by those with Apple Silicon devices using Rosetta. You will 
-need to `have Rosetta installed <https://support.apple.com/en-gb/102527>`__ and 
+For versions of mantid prior to v6.13, only x86 packages are available. These
+can still be used by those with Apple Silicon devices using Rosetta. You will
+need to `have Rosetta installed <https://support.apple.com/en-gb/102527>`__ and
 precede the mamba commands with ``CONDA_SUBDIR=osx-64``.
 
-For example, if you want to install v6.12 of mantidworkbench, use the following 
+For example, if you want to install v6.12 of mantidworkbench, use the following
 command:
 
 .. code-block:: sh

--- a/source/installation/condafaq.rst
+++ b/source/installation/condafaq.rst
@@ -38,12 +38,27 @@ You may also encounter this error when trying to install on Apple silicon device
 Installing on Apple silicon devices
 ###################################
 
-For macOS we currently only provide x86 packages. These can still be used by those with Apple silicon devices (M1, M2). You will need to have Rosetta installed and precede the setup commands with 'CONDA_SUBDIR=osx-64'.
-For example if you want to install mantidworkbench use the following command:
+On macOS we provide both an Intel (x86) and Apple Silicon (ARM) package from 
+v6.13 onwards. Mamba will automatically determine  which package to install
+based on your device.
+
+The processor in your machine can be found by navigating to the ``Apple logo`` 
+-> ``About This Mac``. On an Apple Silicon device, the ``Chip`` 
+line will say ``Apple M`` then a number indicating the version of the chip on
+the device. An Intel device will have a ``Processor`` line, followed by some
+details of the specific CPU used in the device.
+
+For versions of mantid prior to v6.13, only x86 packages are available. These 
+can still be used by those with Apple Silicon devices using Rosetta. You will 
+need to `have Rosetta installed <https://support.apple.com/en-gb/102527>`__ and 
+precede the mamba commands with ``CONDA_SUBDIR=osx-64``.
+
+For example, if you want to install v6.12 of mantidworkbench, use the following 
+command:
 
 .. code-block:: sh
 
-	CONDA_SUBDIR=osx-64 mamba create -n mantid_env -c mantid mantidworkbench
+	CONDA_SUBDIR=osx-64 mamba create -n mantid_env -c mantid mantidworkbench=6.12
 
 .. _dependency_fail:
 

--- a/source/installation/index.rst
+++ b/source/installation/index.rst
@@ -59,8 +59,15 @@ or the ``mantidworkbench`` package containing the graphical-user-interface
 
    mamba create -n mantid_env -c mantid mantidworkbench
 
-For macOS we currently only provide x86 packages. These can still be used by those with Apple silicon devices (M1, M2). You will need to have Rosetta installed and precede the setup commands with 'CONDA_SUBDIR=osx-64'.
-For example if you want to install mantidworkbench use the following command:
+On macOS we provide both an Intel (x86) and Apple Silicon (ARM) package from
+v6.13 onwards. Mamba will automatically determine  which package to install
+based on your device.
+
+Earlier versions of Mantid can still be installed on and used on Apple Silicon
+devices using Rosetta. You will need to `have Rosetta installed
+<https://support.apple.com/en-gb/102527>`__ and precede the setup commands with
+``CONDA_SUBDIR=osx-64``. For example, if you want to install mantidworkbench,
+use the following command:
 
 .. code-block:: sh
 


### PR DESCRIPTION
### Description

Adds additional information about installing on an ARM-based Mac.

Fixes mantidproject/mantid#39096

### To Test

1. Follow the instructions on an ARM mac and check that they work as expected. 